### PR TITLE
record idgen keys in mysql, so, service can reload keys when it restart

### DIFF
--- a/cmd/idgo/main.go
+++ b/cmd/idgo/main.go
@@ -64,6 +64,14 @@ func main() {
 		return
 	}
 
+	err = s.Init()
+	if err != nil {
+		golog.Error("main", "main", err.Error(), 0)
+		golog.GlobalLogger.Close()
+		s.Close()
+		return
+	}
+
 	sc := make(chan os.Signal, 1)
 	signal.Notify(sc,
 		syscall.SIGHUP,


### PR DESCRIPTION
Use a special named table "__idgo__" as service's keys recorder, so, service can reload keys when it restart, not need to reload key in GET method anymore.