### PR TITLE
get not exist key, return (nil)

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -21,8 +21,8 @@ func (s *Server) handleGet(r *Request) Reply {
 
 	if ok == false {
 		s.Unlock()
-		return &IntReply{
-			number: 0,
+		return &BulkReply{
+			value: nil,
 		}
 	}
 


### PR DESCRIPTION
when get a not exist key, it should return "(nil)", but it return "0"