### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Godeps/_workspace/src/github.com/flike/golog/README.md
+++ b/Godeps/_workspace/src/github.com/flike/golog/README.md
@@ -1,8 +1,8 @@
-#golog
+# golog
 
 simple log library for Golang
 
-##case 
+## case 
 
 ```
 package main

--- a/Readme_zh.md
+++ b/Readme_zh.md
@@ -1,6 +1,6 @@
 # idgo 简介
 [![Build Status](https://travis-ci.org/flike/idgo.svg?branch=master)](https://travis-ci.org/flike/idgo)
-##1. idgo特点
+## 1. idgo特点
 
 idgo是一个利用MySQL批量生成ID的ID生成器, 主要有以下特点:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
